### PR TITLE
Update bsplines.py

### DIFF
--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -5,7 +5,6 @@ from sympy.core.compatibility import range
 from sympy.functions import Piecewise, piecewise_fold
 from sympy.sets.sets import Interval
 
-
 def _add_splines(c, b1, d, b2):
     """Construct c*b1 + d*b2."""
     if b1 == S.Zero or c == S.Zero:
@@ -15,72 +14,60 @@ def _add_splines(c, b1, d, b2):
     else:
         new_args = []
         n_intervals = len(b1.args)
-        if n_intervals != len(b2.args):
-            # Args of b1 and b2 are not equal. Just combining the
-            # Piecewise without any fancy optimization
-            p1 = piecewise_fold(c*b1)
-            p2 = piecewise_fold(d*b2)
+        # Just combining the Piecewise without any fancy optimization
+        p1 = piecewise_fold(c*b1)
+        p2 = piecewise_fold(d*b2)
 
-            # Search all Piecewise arguments except (0, True)
-            p2args = list(p2.args[:-1])
+        # Search all Piecewise arguments except (0, True)
+        p2args = list(p2.args[:-1])
 
-            # This merging algorithm assumes the conditions in
-            # p1 and p2 are sorted
-            for arg in p1.args[:-1]:
-                # Conditional of Piecewise are And objects
-                # the args of the And object is a tuple of two
-                # Relational objects the numerical value is in the .rhs
-                # of the Relational object
-                expr = arg.expr
-                cond = arg.cond
+        # This merging algorithm assumes the conditions in
+        # p1 and p2 are sorted
+        for arg in p1.args[:-1]:
+            # Conditional of Piecewise are And objects
+            # the args of the And object is a tuple of two
+            # Relational objects the numerical value is in the .rhs
+            # of the Relational object
+            expr = arg.expr
+            cond = arg.cond
 
-                lower = cond.args[0].rhs
+            lower = cond.args[0].rhs
 
-                # Check p2 for matching conditions that can be merged
-                for i, arg2 in enumerate(p2args):
-                    expr2 = arg2.expr
-                    cond2 = arg2.cond
+            # Check p2 for matching conditions that can be merged
+            for i, arg2 in enumerate(p2args):
+                expr2 = arg2.expr
+                cond2 = arg2.cond
 
-                    lower_2 = cond2.args[0].rhs
-                    upper_2 = cond2.args[1].rhs
+                lower_2 = cond2.args[0].rhs
+                upper_2 = cond2.args[1].rhs
 
-                    if cond2 == cond:
-                        # Conditions match, join expressions
-                        expr += expr2
-                        # Remove matching element
-                        del p2args[i]
-                        # No need to check the rest
-                        break
-                    elif lower_2 < lower and upper_2 <= lower:
-                        # Check if arg2 condition smaller than arg1,
-                        # add to new_args by itself (no match expected
-                        # in p1)
-                        new_args.append(arg2)
-                        del p2args[i]
-                        break
+                if cond2 == cond:
+                    # Conditions match, join expressions
+                    expr += expr2
+                    # Remove matching element
+                    del p2args[i]
+                    # No need to check the rest
+                    break
+                elif lower_2 < lower and upper_2 <= lower:
+                    # Check if arg2 condition smaller than arg1,
+                    # add to new_args by itself (no match expected
+                    # in p1)
+                    new_args.append(arg2)
+                    del p2args[i]
+                    break
 
-                # Checked all, add expr and cond
-                new_args.append((expr, cond))
+            # Checked all, add expr and cond
+            new_args.append((expr, cond))
 
-            # Add remaining items from p2args
-            new_args.extend(p2args)
+        # Add remaining items from p2args
+        new_args.extend(p2args)
 
-            # Add final (0, True)
-            new_args.append((0, True))
-        else:
-            new_args.append((c*b1.args[0].expr, b1.args[0].cond))
-            for i in range(1, n_intervals - 1):
-                new_args.append((
-                    c*b1.args[i].expr + d*b2.args[i - 1].expr,
-                    b1.args[i].cond
-                ))
-            new_args.append((d*b2.args[-2].expr, b2.args[-2].cond))
-            new_args.append(b2.args[-1])
+        # Add final (0, True)
+        new_args.append((0, True))
 
         rv = Piecewise(*new_args)
 
     return rv.expand()
-
 
 def bspline_basis(d, knots, n, x):
     """The `n`-th B-spline at `x` of degree `d` with knots.


### PR DESCRIPTION
There is a bug with bspline basis functions construction for a case when the number of control points is small. The removed bit in _add_splines does something weird, while the first part works fine itself.

Here's an example of a wrong behaviour:
```
import sympy
from sympy.functions.special.bsplines import bspline_basis
x = sympy.var("x")
kv = [0, 0, 0, 0, 1, 2, 2, 2, 2]
basis = bspline_basis(3, kv, 2, x)
```
The expected basis function should be continuous at x == 1, while in the current version it is not.
I computed the expected analytical formula by hand and compared to the one the old version produces. They do not match.
```
assert basis = sympy.Piecewise((-x**3 + 3*x**2/2, (x >= 0) & (x <= 1)), (x**3 - 9*x**2/2 + 6*x - 2, (x >= 1) & (x <= 2)), (0, True))
```
With this change we fix the wrong behaviour of the middle basis function, which is only reproducible when the number of control points is small.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
